### PR TITLE
Add ca-certificates to consul-template image

### DIFF
--- a/consul-template/Dockerfile
+++ b/consul-template/Dockerfile
@@ -23,7 +23,8 @@ RUN unzip consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip && \
   mv consul-template /usr/local/bin/consul-template &&\
   rm -rf /consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip && \
   rm -rf /consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64 && \
-  mkdir -p /consul-template /consul-template/config.d /consul-template/templates
+  mkdir -p /consul-template /consul-template/config.d /consul-template/templates && \
+  apk add --update ca-certificates
 
 COPY root.conf /consul-template/config.d
 


### PR DESCRIPTION
Without this, we get "x509: failed to load system roots and no roots provided" when talking to vault.